### PR TITLE
fix: fix rendering error in App

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,26 +2,30 @@ import Route from "./components/utils/Route.jsx";
 import Login from "./pages/Login.jsx"
 import Dashboard from "./pages/Dashboard.jsx";
 import useNavigation from "./hooks/useNavigation.js";
+import { useEffect } from "react";
 
 const App = () => {
   const userId = window.localStorage.getItem("biscut");
   const { navigate, currentPath } = useNavigation();
-  
-  let checker = currentPath.includes("/dashboard")
-  
-  if(!checker)
-  {
-    if (!userId) {
-      navigate("/login");
-    } else {
-      navigate("/dashboard");
+ 
+  let isDashboard = currentPath.includes("/dashboard")
+  useEffect(() => {
+    
+    if(!isDashboard)
+    {
+      if (!userId) {
+        navigate("/login");
+      } else {
+        navigate("/dashboard");
+      }
     }
-  }
+
+  }, []);
 
   return (
     <div className="bg-[#09090b] w-screen h-screen flex flex-col justify-center items-center">
       <Route path='/login'><Login /></Route>
-      {checker && <Dashboard />}
+      {isDashboard && <Dashboard />}
     </div>
   );
 }


### PR DESCRIPTION
Error - Cannot update a component (NavigationProvider) while rendering a different component (App)

Reason - React disallows state updates during the render phase because it leads to inconsistencies and infinite render loops. When I call navigate() inside the render function of App, It's indirectly updating the state in NavigationProvider before App finishes rendering, which leads to React flags as an error.

Solution - Ensure that state updates like navigate() are triggered outside the render phase—for example, in an effect (useEffect). Here useEffect ensures that navigate is called only after the render of App. React allows state updates in lifecycle methods like effects.